### PR TITLE
Update versioning logic and enhance release workflow

### DIFF
--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -17,11 +17,24 @@ jobs:
           # Extract current version
           VERSION=$(grep -oP '(?<=<Version>)[^<]+' src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj)
 
-          # Parse and increment minor version
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          MINOR=$(echo $VERSION | cut -d. -f2)
-          PATCH=$(echo $VERSION | cut -d. -f3)
-          NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
+          # Parse base version (strip prerelease if present)
+          if [[ "$VERSION" == *-* ]]; then
+            BASE_VERSION="${VERSION%%-*}"
+          else
+            BASE_VERSION="$VERSION"
+          fi
+
+          # Increment minor version
+          MAJOR=$(echo "$BASE_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$BASE_VERSION" | cut -d. -f2)
+          NEW_BASE_VERSION="$MAJOR.$((MINOR + 1)).0"
+
+          # Add prerelease if original had prerelease
+          if [[ "$VERSION" == *-* ]]; then
+            NEW_VERSION="${NEW_BASE_VERSION}-preview.1"
+          else
+            NEW_VERSION="$NEW_BASE_VERSION"
+          fi
 
           # Update .csproj file
           sed -i "s/<Version>$VERSION<\/Version>/<Version>$NEW_VERSION<\/Version>/" src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,9 +33,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Restore
         run: dotnet restore
+      - name: Define build outputs
+        id: outputs
+        run: |
+          echo "artifact_dir=${{ github.workspace }}/artifacts/output" >> "$GITHUB_OUTPUT"
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj --configuration Release --no-restore --output "${{ steps.outputs.outputs.artifact_dir }}"
+      - name: Attest release binary
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "${{ steps.outputs.outputs.artifact_dir }}/AzureSdk.SamplesMcp"
       - name: Pack NuGet
-        run: dotnet pack src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj --configuration Release --no-build --output nupkg
+        run: dotnet pack src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj --configuration Release --no-build --output "${{ steps.outputs.outputs.artifact_dir }}"
+      - name: Attest NuGet package
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "${{ steps.outputs.outputs.artifact_dir }}/*.nupkg"
       - name: Publish NuGet
-        run: dotnet nuget push nupkg/*.nupkg --source "https://nuget.pkg.github.com/heaths/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+        run: dotnet nuget push "${{ steps.outputs.outputs.artifact_dir }}/*.nupkg" --source "https://nuget.pkg.github.com/heaths/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+artifacts/
 bin/
 obj/
 TestResults/

--- a/src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj
+++ b/src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.1.0-preview.1</Version>
     <OutputType>Exe</OutputType>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Refactor the version bumping process to correctly handle prerelease versions. The workflow now increments the minor version and appends a prerelease tag if the original version was a prerelease. Additionally, the release workflow has been updated to define build outputs and attest both the release binary and NuGet package, ensuring better artifact management and traceability.
