### PR TITLE
Rename .NET tool and add config command

### DIFF
--- a/.copilot/mcp-config.json
+++ b/.copilot/mcp-config.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "azsdk-samples": {
-      "type": "local",
+      "type": "stdio",
       "command": "dotnet",
       "args": [
         "run",

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Azure SDK Samples MCP
 
-An MCP (Model Context Protocol) server that discovers and retrieves code samples from Azure SDK packages. This server provides AI agents and coding assistants with direct access to real-world examples from Azure SDK dependencies, helping developers use the Azure SDKs safely and effectively.
-
-## Overview
-
-When working with Azure SDKs, having access to relevant code examples can significantly improve development efficiency and reduce errors. This MCP server automatically discovers Azure SDK samples from your project's dependencies (NuGet, npm, Cargo) and makes them available to AI agents like GitHub Copilot.
+An MCP (Model Context Protocol) server that discovers and retrieves code samples from Azure SDK packages. When working with Azure SDKs, having access to relevant code examples can significantly improve development efficiency and reduce errors. This MCP server automatically discovers Azure SDK samples from your project's dependencies (NuGet, npm, Cargo) and makes them available to AI agents and coding assistants like GitHub Copilot.
 
 **Key features:**
 
@@ -19,9 +15,9 @@ When working with Azure SDKs, having access to relevant code examples can signif
 
 ## Installation
 
-### Quick Start
+### Install as a Global Tool
 
-1. **Authenticate with GitHub Packages** (required even for public packages):
+1. **Authenticate with GitHub Packages** (required only once even for public packages):
 
    First, create a [GitHub Personal Access Token (PAT)](https://github.com/settings/tokens/new) with `read:packages` scope.
 
@@ -39,57 +35,95 @@ When working with Azure SDKs, having access to relevant code examples can signif
 
    > **Note:** The `--store-password-in-clear-text` flag stores the token in plaintext in your NuGet configuration file. This is required because encrypted storage is not supported on all platforms. Keep your token secure and avoid committing NuGet configuration files to version control.
 
-2. Install the MCP server as a global tool:
+2. **Install the MCP server as a global tool:**
 
    ```bash
    dotnet tool install --global AzureSdk.SamplesMcp --add-source github-heaths --prerelease
    ```
 
-3. Add to VS Code settings (⌘, on macOS, Ctrl+, on Windows/Linux):
-   - Search for "MCP Servers" and find your AI extension settings
-   - Add this configuration:
+   > **Note for existing users:** If you previously installed this tool with the old command name (`AzureSdk.SamplesMcp`), you must uninstall it first:
+   >
+   > ```bash
+   > dotnet tool uninstall --global AzureSdk.SamplesMcp
+   > ```
+   >
+   > Then install the new version as shown above. The command name is now `azsdk-samples`.
 
-     ```json
-     {
-       "azsdk-samples": {
-         "command": "AzureSdk.SamplesMcp",
-         "args": []
-       }
-     }
-     ```
+### Clone the Repository (Optional)
 
-4. Restart VS Code to load the MCP server
+If you prefer to run from source or contribute to the project:
 
-### Building from Source (Optional)
+```bash
+git clone https://github.com/heaths/azsdk-samples-mcp.git
+cd azsdk-samples-mcp
+```
 
-If you prefer to run locally from source:
+You can automatically configured the server as described blow:
 
-1. Clone the repository:
+```bash
+dotnet run --project src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj -- config copilot
+```
 
-   ```bash
-   git clone https://github.com/heaths/azsdk-samples-mcp.git
-   cd azsdk-samples-mcp
-   ```
+Or just build it to configure it manually, also described below:
 
-2. Update VS Code settings to run from source:
+```bash
+dotnet build
+```
 
-   ```json
-   {
-     "azsdk-samples": {
-       "command": "dotnet",
-       "args": [
-         "run",
-         "--project",
-         "/path/to/azsdk-samples-mcp/src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj",
-         "--"
-       ]
-     }
-   }
-   ```
+## Configuration
 
-   Replace `/path/to/azsdk-samples-mcp` with the actual location of your cloned repository.
+### Automatic Configuration
 
-3. Restart VS Code to load the MCP server
+Use the `config` command to automatically generate MCP configuration files:
+
+```bash
+# Configure for GitHub Copilot (local - in repository)
+azsdk-samples config copilot
+
+# Configure for GitHub Copilot (global)
+azsdk-samples config copilot --global
+
+# Configure for VS Code (local only)
+azsdk-samples config vscode
+
+# Configure for Claude Code (local)
+azsdk-samples config claude
+
+# Configure for Claude Code (global)
+azsdk-samples config claude --global
+```
+
+This will create or update the appropriate configuration files:
+
+- **Copilot**: `.copilot/mcp-config.json` (local) or `~/.copilot/mcp-config.json` (global)
+- **VS Code**: `.vscode/mcp.json` (local only)
+- **Claude Code**: `.mcp.json` (local) or `~/.claude.json` (global)
+
+> **Note:** For global configurations, the command assumes you have the tool installed globally. For local configurations, it will find your repository root (by looking for `.git`) and create the config there.
+
+### Manual Configuration
+
+For more control or troubleshooting, you can manually configure the MCP server:
+
+- **Copilot**: See [Extend coding agent with MCP](https://docs.github.com/copilot/how-tos/use-copilot-agents/coding-agent/extend-coding-agent-with-mcp)
+- **VS Code**: See [Use MCP servers in Visual Studio Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
+- **Claude Code**: See [Model Context Protocol](https://code.claude.com/docs/en/mcp)
+
+#### Example: Manual VS Code Configuration
+
+Create or edit `.vscode/mcp.json` in your repository:
+
+```json
+{
+  "servers": {
+    "azsdk-samples": {
+      "type": "stdio",
+      "command": "azsdk-samples"
+    }
+  },
+  "inputs": []
+}
+```
 
 ## Usage
 

--- a/src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj
+++ b/src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.1.0-preview.2</Version>
+    <Version>0.2.0-preview.1</Version>
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
+    <ToolCommandName>azsdk-samples</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
     <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AzureSdk.SamplesMcp/CommandLine.cs
+++ b/src/AzureSdk.SamplesMcp/CommandLine.cs
@@ -1,0 +1,54 @@
+// Copyright 2026 Heath Stewart.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+
+namespace AzureSdk.SamplesMcp;
+
+internal static class CommandLine
+{
+    public static RootCommand Build()
+    {
+        RootCommand rootCommand = new("Azure SDK Samples MCP Server - discover and retrieve code samples from Azure SDK dependencies");
+
+        // Default action: start the MCP server
+        rootCommand.SetAction(async parseResult =>
+        {
+            await Program.StartMcpServerAsync();
+            return 0;
+        });
+
+        // Add config subcommand
+        Command configCommand = new("config", "Generate MCP configuration files for AI assistants");
+
+        Argument<string> targetArgument = new("target")
+        {
+            Description = "Target AI assistant (copilot, claude, or vscode)"
+        };
+
+        Option<bool> globalOption = new("--global")
+        {
+            Description = "Create global configuration instead of local (repository-level)"
+        };
+        globalOption.Aliases.Add("-g");
+
+        configCommand.Arguments.Add(targetArgument);
+        configCommand.Options.Add(globalOption);
+
+        configCommand.SetAction(async parseResult =>
+        {
+            string? target = parseResult.GetValue(targetArgument);
+            bool isGlobal = parseResult.GetValue(globalOption);
+            if (target is null)
+            {
+                return 1;
+            }
+            return await ConfigCommandHandler.HandleAsync(target, isGlobal);
+        });
+
+        rootCommand.Subcommands.Add(configCommand);
+
+        return rootCommand;
+    }
+}

--- a/src/AzureSdk.SamplesMcp/ConfigCommandHandler.cs
+++ b/src/AzureSdk.SamplesMcp/ConfigCommandHandler.cs
@@ -1,0 +1,273 @@
+// Copyright 2026 Heath Stewart.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace AzureSdk.SamplesMcp;
+
+internal static class ConfigCommandHandler
+{
+    private const string ProjectFileName = "AzureSdk.SamplesMcp.csproj";
+    private const string ServerName = "azsdk-samples";
+
+    public static async Task<int> HandleAsync(string target, bool isGlobal)
+    {
+        // Validate target
+        if (target != "copilot" && target != "claude" && target != "vscode")
+        {
+            Console.Error.WriteLine($"Error: Unknown target '{target}'. Valid targets are: copilot, claude, vscode");
+            return 1;
+        }
+
+        // Validate vscode + global combination
+        if (target == "vscode" && isGlobal)
+        {
+            Console.Error.WriteLine("Error: VS Code configuration does not support --global flag.");
+            Console.Error.WriteLine("Use VS Code settings.json for global configuration instead.");
+            return 1;
+        }
+
+        // Determine config file path
+        string? configPath = GetConfigPath(target, isGlobal);
+        if (configPath is null)
+        {
+            Console.Error.WriteLine($"Error: Could not determine configuration path for {target}.");
+            if (!isGlobal)
+            {
+                Console.Error.WriteLine("Could not find repository root (no .git directory found).");
+            }
+            return 1;
+        }
+
+        // Create or update config file
+        try
+        {
+            await CreateOrUpdateConfigAsync(configPath, target);
+            Console.WriteLine($"Successfully created/updated configuration at: {configPath}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error creating configuration: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static string? GetConfigPath(string target, bool isGlobal)
+    {
+        if (isGlobal)
+        {
+            string homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return target switch
+            {
+                "copilot" => Path.Combine(homeDir, ".copilot", "mcp-config.json"),
+                "claude" => Path.Combine(homeDir, ".claude.json"),
+                _ => null
+            };
+        }
+        else
+        {
+            string? repoRoot = FindRepositoryRoot();
+            if (repoRoot is null)
+            {
+                return null;
+            }
+
+            return target switch
+            {
+                "copilot" => Path.Combine(repoRoot, ".copilot", "mcp-config.json"),
+                "claude" => Path.Combine(repoRoot, ".mcp.json"),
+                "vscode" => Path.Combine(repoRoot, ".vscode", "mcp.json"),
+                _ => null
+            };
+        }
+    }
+
+    private static string? FindRepositoryRoot()
+    {
+        string? currentDir = Directory.GetCurrentDirectory();
+
+        while (currentDir is not null)
+        {
+            string gitPath = Path.Combine(currentDir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return currentDir;
+            }
+
+            currentDir = Path.GetDirectoryName(currentDir);
+        }
+
+        return null;
+    }
+
+    private static string? FindProjectFile()
+    {
+        // Start from the executable's directory
+        string? executablePath = Environment.ProcessPath;
+        if (executablePath is null)
+        {
+            return null;
+        }
+
+        string? currentDir = Path.GetDirectoryName(executablePath);
+        string? repoRoot = FindRepositoryRoot();
+
+        // Search from executable directory up to repository root
+        while (currentDir is not null)
+        {
+            string projectPath = Path.Combine(currentDir, ProjectFileName);
+            if (File.Exists(projectPath))
+            {
+                return projectPath;
+            }
+
+            // Stop at repository root
+            if (currentDir == repoRoot)
+            {
+                break;
+            }
+
+            currentDir = Path.GetDirectoryName(currentDir);
+        }
+
+        return null;
+    }
+
+    private static string GetCommandName()
+    {
+        string? processPath = Environment.ProcessPath;
+        if (processPath is not null)
+        {
+            return Path.GetFileName(processPath);
+        }
+
+        return ServerName;
+    }
+
+    private static (string command, JsonArray? args) GetCommandConfiguration()
+    {
+        string? projectPath = FindProjectFile();
+
+        if (projectPath is not null)
+        {
+            // Running from source - use dotnet run with relative path
+            string? repoRoot = FindRepositoryRoot();
+            string relativePath = projectPath;
+
+            if (repoRoot is not null && projectPath.StartsWith(repoRoot))
+            {
+                relativePath = Path.GetRelativePath(repoRoot, projectPath);
+            }
+
+            JsonArray args = new() { "run", "--project", relativePath, "--" };
+            return ("dotnet", args);
+        }
+        else
+        {
+            // Using installed tool
+            return (GetCommandName(), null);
+        }
+    }
+
+    private static async Task CreateOrUpdateConfigAsync(string configPath, string target)
+    {
+        // Ensure parent directory exists
+        string? directory = Path.GetDirectoryName(configPath);
+        if (directory is not null && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        // Determine command configuration
+        (string command, JsonArray? args) = GetCommandConfiguration();
+
+        // Read existing config or create new
+        JsonObject rootConfig;
+        if (File.Exists(configPath))
+        {
+            string existingContent = await File.ReadAllTextAsync(configPath);
+            rootConfig = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+        }
+        else
+        {
+            rootConfig = new JsonObject();
+        }
+
+        // Build server configuration
+        JsonObject serverConfig = BuildServerConfig(target, command, args);
+
+        // Add to appropriate section based on target
+        if (target == "vscode")
+        {
+            AddVsCodeConfig(rootConfig, serverConfig);
+        }
+        else
+        {
+            AddMcpServerConfig(rootConfig, serverConfig);
+        }
+
+        // Write config file
+        JsonSerializerOptions options = new()
+        {
+            WriteIndented = true
+        };
+        string jsonContent = rootConfig.ToJsonString(options);
+        await File.WriteAllTextAsync(configPath, jsonContent);
+    }
+
+    private static JsonObject BuildServerConfig(string target, string command, JsonArray? args)
+    {
+        JsonObject serverConfig = new()
+        {
+            ["type"] = "stdio",
+            ["command"] = command
+        };
+
+        // Add args if present
+        if (args is not null)
+        {
+            serverConfig["args"] = args;
+        }
+
+        // Add tools for Copilot
+        if (target == "copilot")
+        {
+            serverConfig["tools"] = new JsonArray { "*" };
+        }
+
+        return serverConfig;
+    }
+
+    private static void AddVsCodeConfig(JsonObject rootConfig, JsonObject serverConfig)
+    {
+        // VS Code uses "servers" not "mcpServers"
+        if (!rootConfig.ContainsKey("servers"))
+        {
+            rootConfig["servers"] = new JsonObject();
+        }
+
+        // Ensure inputs array exists
+        if (!rootConfig.ContainsKey("inputs"))
+        {
+            rootConfig["inputs"] = new JsonArray();
+        }
+
+        JsonObject servers = rootConfig["servers"]!.AsObject();
+        servers[ServerName] = serverConfig;
+    }
+
+    private static void AddMcpServerConfig(JsonObject rootConfig, JsonObject serverConfig)
+    {
+        // Copilot and Claude use "mcpServers"
+        if (!rootConfig.ContainsKey("mcpServers"))
+        {
+            rootConfig["mcpServers"] = new JsonObject();
+        }
+
+        JsonObject mcpServers = rootConfig["mcpServers"]!.AsObject();
+        mcpServers[ServerName] = serverConfig;
+    }
+}

--- a/src/AzureSdk.SamplesMcp/Program.cs
+++ b/src/AzureSdk.SamplesMcp/Program.cs
@@ -1,24 +1,34 @@
 // Copyright 2026 Heath Stewart.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
+using System.CommandLine.Parsing;
 using AzureSdk.SamplesMcp;
 using AzureSdk.SamplesMcp.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
-builder.Logging.AddConsole(options =>
+var parseResult = CommandLine.Build().Parse(args);
+return parseResult.Invoke();
+
+internal static partial class Program
 {
-    options.LogToStandardErrorThreshold = LogLevel.Debug;
-});
-builder.Logging.SetMinimumLevel(LogLevel.Debug);
-builder.Services
-    .AddSingleton(DefaultEnvironment.Default)
-    .AddSingleton(FileSystem.Default)
-    .AddSingleton<IExternalProcessService, ExternalProcessService>()
-    .AddMcpServer()
-    .WithStdioServerTransport()
-    .WithToolsFromAssembly()
-    .WithPromptsFromAssembly();
-await builder.Build().RunAsync();
+    public static async Task StartMcpServerAsync()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Logging.AddConsole(options =>
+        {
+            options.LogToStandardErrorThreshold = LogLevel.Debug;
+        });
+        builder.Logging.SetMinimumLevel(LogLevel.Debug);
+        builder.Services
+            .AddSingleton(DefaultEnvironment.Default)
+            .AddSingleton(FileSystem.Default)
+            .AddSingleton<IExternalProcessService, ExternalProcessService>()
+            .AddMcpServer()
+            .WithStdioServerTransport()
+            .WithToolsFromAssembly()
+            .WithPromptsFromAssembly();
+        await builder.Build().RunAsync();
+    }
+}


### PR DESCRIPTION
.NET tool is now called `azsdk-samples` and I added a `config` command to configure Copilot coding agents, VSCode, and Claude code.
