### PR TITLE
Publish to nuget.org with trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,12 @@ jobs:
         with:
           dotnet-version: 10.0.x
       - name: Create Release
-        run: gh release create ${{ github.ref_name }} --generate-notes
+        run: |
+          if [[ "${{ github.ref_name }}" == *-* ]]; then
+            gh release create ${{ github.ref_name }} --generate-notes --prerelease
+          else
+            gh release create ${{ github.ref_name }} --generate-notes
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Restore
@@ -38,16 +43,38 @@ jobs:
         run: |
           echo "artifact_dir=${{ github.workspace }}/artifacts/output" >> "$GITHUB_OUTPUT"
       - name: Build
-        run: dotnet build src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj --configuration Release --no-restore -p:OutputPath="${{ steps.outputs.outputs.artifact_dir }}"
+        run: >-
+          dotnet build
+            src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj
+            --configuration Release
+            --no-restore
+            -p:OutputPath="${{ steps.outputs.outputs.artifact_dir }}"
       - name: Attest release binary
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: "${{ steps.outputs.outputs.artifact_dir }}/AzureSdk.SamplesMcp.dll"
       - name: Pack NuGet
-        run: dotnet pack src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj --configuration Release --no-build -p:OutputPath="${{ steps.outputs.outputs.artifact_dir }}" -p:PackageOutputPath="${{ steps.outputs.outputs.artifact_dir }}" /p:NoWarn=NU5104
+        run: >-
+          dotnet pack
+            src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj
+            --configuration Release
+            --no-build
+            -p:OutputPath="${{ steps.outputs.outputs.artifact_dir }}"
+            -p:PackageOutputPath="${{ steps.outputs.outputs.artifact_dir }}"
+            /p:NoWarn=NU5104
       - name: Attest NuGet package
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: "${{ steps.outputs.outputs.artifact_dir }}/*.nupkg"
-      - name: Publish NuGet
-        run: dotnet nuget push "${{ steps.outputs.outputs.artifact_dir }}/*.nupkg" --source "https://nuget.pkg.github.com/heaths/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+      - name: Log into NuGet.org
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: heaths
+      - name: Publish to NuGet.org
+        run: >-
+          dotnet nuget push
+            "${{ steps.outputs.outputs.artifact_dir }}/*.nupkg"
+            --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
+            --source https://api.nuget.org/v3/index.json
+            --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Azure SDK Samples MCP
+# Azure SDK Samples MCP (Unofficial)
+
+<!-- mcp-name: io.github.heaths/azsdk-samples-mcp -->
+
+[![release](https://img.shields.io/github/v/release/heaths/azsdk-samples-mcp.svg?logo=github&include_prereleases)](https://github.com/heaths/azsdk-samples-mcp/releases/latest)
+[![ci](https://github.com/heaths/azsdk-samples-mcp/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/heaths/azsdk-samples-mcp/actions/workflows/ci.yml)
 
 An MCP (Model Context Protocol) server that discovers and retrieves code samples from Azure SDK packages. When working with Azure SDKs, having access to relevant code examples can significantly improve development efficiency and reduce errors. This MCP server automatically discovers Azure SDK samples from your project's dependencies (NuGet, npm, Cargo) and makes them available to AI agents and coding assistants like GitHub Copilot.
 
@@ -17,37 +22,11 @@ An MCP (Model Context Protocol) server that discovers and retrieves code samples
 
 ### Install as a Global Tool
 
-1. **Authenticate with GitHub Packages** (required only once even for public packages):
+Install the MCP server as a global .NET tool from nuget.org:
 
-   First, create a [GitHub Personal Access Token (PAT)](https://github.com/settings/tokens/new) with `read:packages` scope.
-
-   Then, configure the NuGet source with your GitHub username and token:
-
-   ```bash
-   dotnet nuget add source "https://nuget.pkg.github.com/heaths/index.json" \
-     --name github-heaths \
-     --username YOUR_GITHUB_USERNAME \
-     --password YOUR_GITHUB_TOKEN \
-     --store-password-in-clear-text
-   ```
-
-   Replace `YOUR_GITHUB_USERNAME` with your GitHub username (without quotes) and `YOUR_GITHUB_TOKEN` with your PAT (without quotes).
-
-   > **Note:** The `--store-password-in-clear-text` flag stores the token in plaintext in your NuGet configuration file. This is required because encrypted storage is not supported on all platforms. Keep your token secure and avoid committing NuGet configuration files to version control.
-
-2. **Install the MCP server as a global tool:**
-
-   ```bash
-   dotnet tool install --global AzureSdk.SamplesMcp --add-source github-heaths --prerelease
-   ```
-
-   > **Note for existing users:** If you previously installed this tool with the old command name (`AzureSdk.SamplesMcp`), you must uninstall it first:
-   >
-   > ```bash
-   > dotnet tool uninstall --global AzureSdk.SamplesMcp
-   > ```
-   >
-   > Then install the new version as shown above. The command name is now `azsdk-samples`.
+```bash
+dotnet tool install --global AzureSdk.SamplesMcp --prerelease
+```
 
 ### Clone the Repository (Optional)
 

--- a/src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj
+++ b/src/AzureSdk.SamplesMcp/AzureSdk.SamplesMcp.csproj
@@ -3,9 +3,30 @@
   <PropertyGroup>
     <Version>0.3.0-preview.1</Version>
     <OutputType>Exe</OutputType>
+
     <IsPackable>true</IsPackable>
-    <PackAsTool>true</PackAsTool>
     <ToolCommandName>azsdk-samples</ToolCommandName>
+    <PackAsTool>true</PackAsTool>
+    <PackageType>McpServer</PackageType>
+    <SelfContained>true</SelfContained>
+    <PublishSelfContained>true</PublishSelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+
+    <Description>
+<![CDATA[
+  An MCP (Model Context Protocol) server that discovers and retrieves code samples from Azure SDK packages.
+  When working with Azure SDKs, having access to relevant code examples can significantly improve development efficiency and reduce errors.
+  This MCP server automatically discovers Azure SDK samples from your project's dependencies (NuGet, npm, Cargo)
+  and makes them available to AI agents and coding assistants like GitHub Copilot.
+]]>
+    </Description>
+    <PackageTags>AI; MCP; server; stdio</PackageTags>
+
+    <!-- MCP server.json properties -->
+    <McpServerName>io.github.heaths/azsdk-samples-mcp</McpServerName>
+    <McpServerDescription>Discovers and retrieves code samples from Azure SDK packages in .NET, Node.js, and Rust projects.</McpServerDescription>
+    <McpRepositoryUrl>https://github.com/heaths/azsdk-samples-mcp</McpRepositoryUrl>
+    <GeneratedServerJsonPath>$(IntermediateOutputPath)server.json</GeneratedServerJsonPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,5 +40,40 @@
   <ItemGroup>
     <Using Remove="System.IO" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(GeneratedServerJsonPath)" Pack="true" PackagePath="/.mcp/" />
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+  <Target Name="GenerateServerJson" BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+      <ServerJsonContent>
+<![CDATA[{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "description": "$(McpServerDescription)",
+  "name": "$(McpServerName)",
+  "version": "$(Version)",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "identifier": "$(PackageId)",
+      "version": "$(Version)",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [],
+      "environmentVariables": []
+    }
+  ],
+  "repository": {
+    "url": "$(McpRepositoryUrl)",
+    "source": "github"
+  }
+}]]>
+      </ServerJsonContent>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(GeneratedServerJsonPath)" Lines="$(ServerJsonContent)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
Updated release workflow to use NuGet.org trusted publishing via OIDC
instead of GitHub Packages. The workflow now uses the NuGet/login action
to obtain a short-lived API key and publishes packages to nuget.org.
Added prerelease detection to automatically mark releases appropriately.
Formatted long command lines using YAML folded block scalars for improved
readability.

Updated README.md to remove GitHub Packages authentication instructions,
add status badges for releases and CI, mark the project as unofficial,
and include the mcp-name comment required for MCP registry publication.

Modified the csproj to dynamically generate server.json during pack using
MSBuild targets. This eliminates duplicate version maintenance by using
project properties. The generated file is placed in the intermediate
output directory and included in the package as .mcp/server.json.